### PR TITLE
Add legacy OpenSSL provider flag to webpack scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha --require babel-core/register",
-    "build": "webpack --mode=production",
-    "watch": "webpack --watch --mode=development"
+    "build": "NODE_OPTIONS=--openssl-legacy-provider webpack --mode=production",
+    "watch": "NODE_OPTIONS=--openssl-legacy-provider webpack --watch --mode=development"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Motivation
- Address OpenSSL 3 hashing errors (`ERR_OSSL_EVP_UNSUPPORTED`) encountered when running `npm run build` / `webpack` on modern Node.js by enabling the legacy OpenSSL provider.

### Description
- Update `package.json` to prefix the `build` and `watch` scripts with `NODE_OPTIONS=--openssl-legacy-provider` so webpack runs with the legacy OpenSSL provider.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69749db1f6648325bee514b8aa207f45)