### PR TITLE
Add ACM TOCE survey (2025) to publications

### DIFF
--- a/index.html
+++ b/index.html
@@ -294,6 +294,12 @@
           </a>
         </li>
         <li class="list-group-item">
+          <a href="https://doi.org/10.1145/3773911" target="_blank">
+            <i class="fas fa-check-circle" style="color: #0077b5;"></i>
+            Eduard Frankford, Tobias Antensteiner, Michael Vierhauser, Clemens Sauerwein, Vivien Wallner, Iris Groher, Reinhold Plösch, and Ruth Breu. 2025. A Survey on Feedback Types in Automated Programming Assessment Systems. ACM Trans. Comput. Educ. 26, 1, Article 14 (March 2026). https://doi.org/10.1145/3773911
+          </a>
+        </li>
+        <li class="list-group-item">
           <a href="https://www.scitepress.org/Papers/2024/125564/125564.pdf" target="_blank">
             <i class="fas fa-check-circle" style="color: #0077b5;"></i>
             Frankford, Eduard, et al. "Requirements for an Online Integrated Development Environment for Automated Programming Assessment Systems." CSEDU (1). 2024.


### PR DESCRIPTION
### Motivation
- Add the new ACM Transactions on Computing Education survey entry (DOI: 10.1145/3773911) to the website publications list so the site reflects the latest paper.

### Description
- Inserted a new `<li>` entry with the formatted citation and DOI link into `index.html` under the Publications section and committed the change.

### Testing
- Rendered `index.html` via a local server started with `python -m http.server 3000` and captured a screenshot with Playwright of `http://127.0.0.1:3000/index.html`, which produced `artifacts/publications.png` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974a0b2a44883259fedfaf26416eeec)