### PR TITLE
Remove legacy OpenSSL flag from build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha --require @babel/register",
-    "build": "NODE_OPTIONS=--openssl-legacy-provider webpack --mode=production",
-    "watch": "NODE_OPTIONS=--openssl-legacy-provider webpack --watch --mode=development"
+    "build": "webpack --mode=production",
+    "watch": "webpack --watch --mode=development"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Motivation
- Remove the `NODE_OPTIONS=--openssl-legacy-provider` flag from npm scripts because Netlify rejects `--openssl-legacy-provider` in `NODE_OPTIONS`, which caused builds to fail with the error "node: --openssl-legacy-provider is not allowed in NODE_OPTIONS".

### Description
- Deleted `NODE_OPTIONS=--openssl-legacy-provider` from the `build` and `watch` scripts in `package.json`, so `build` now runs `webpack --mode=production` and `watch` runs `webpack --watch --mode=development`.

### Testing
- No automated tests were run after this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974a163e76c83258aae8afd9dd50bf0)